### PR TITLE
Add support for OS X

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -1,6 +1,7 @@
 (cl:in-package :%open-asset-import-library)
 
 (define-foreign-library assimp
+  (:darwin "libassimp.dylib")
   (:windows "assimp.dll" );; :calling-convention :stdcall ?
   #++(:unix "libassimp.so")
   (:unix (:or "libassimp.so.3" "libassimp3.0.so" "libassimp.so")))


### PR DESCRIPTION
libassimp can be installed by:
> brew install assimp