### PR TITLE
Allow 4.0 version of assimp

### DIFF
--- a/low-level.lisp
+++ b/low-level.lisp
@@ -16,12 +16,12 @@
       (cl:values new-version major minor)))
   (cl:defun %v= (req)
     (cl:ecase req
-      (:3.0-3.3 (cl:member *version* '(:3.0 :3.1 :3.2 :3.3))) ;; exact versions
-      (:3.0+ (cl:member *version* '(:3.0 :3.1 :3.2 :3.3)))
-      (:3.1+ (cl:member *version* '(:3.1 :3.2 :3.3)))
-      (:3.2+ (cl:member *version* '(:3.2 :3.3)))
-      (:3.3+ (cl:member *version* '(:3.3)))
-      (:>3.3 ()))))
+      (:3.0-3.3 (cl:member *version* '(:3.0 :3.1 :3.2 :3.3 :4.0))) ;; exact versions
+      (:3.0+ (cl:member *version* '(:3.0 :3.1 :3.2 :3.3 :4.0)))
+      (:3.1+ (cl:member *version* '(:3.1 :3.2 :3.3 :4.0)))
+      (:3.2+ (cl:member *version* '(:3.2 :3.3 :4.0)))
+      (:3.3+ (cl:member *version* '(:3.3 :4.0)))
+      (:>3.3 (cl:member *version* '(:4.0))))))
 
 (cl:eval-when (:compile-toplevel)
   (cl:setf *compiled* cl:t)
@@ -30,8 +30,10 @@
     (cl:multiple-value-bind (new-version major minor)
         (get-version-keyword)
       (cl:when (cl:and major minor)
-        (cl:unless (cl:and (cl:= major 3)
-                           (cl:<= 0 minor 3))
+        (cl:unless (cl:or (cl:and (cl:= major 3)
+                                  (cl:<= 0 minor 3))
+                          (cl:and (cl:= major 4)
+                                  (cl:<= 0 minor 0)))
           (cl:error "trying to link against unsupported version of assimp. 3.0-3.3.x supported, got version ~a.~a"
                     major minor))
         (cl:setf *version* new-version)))))
@@ -41,8 +43,10 @@
     (cl:multiple-value-bind (new-version major minor)
         (get-version-keyword)
       (cl:when (cl:and major minor)
-        (cl:unless (cl:and (cl:= major 3)
-                           (cl:<= 0 minor 3))
+        (cl:unless (cl:or (cl:and (cl:= major 3)
+                                  (cl:<= 0 minor 3))
+                          (cl:and (cl:= major 4)
+                                  (cl:<= 0 minor 0)))
           (cl:error "trying to link against unsupported version of assimp. 3.0-3.3.x supported, got version ~a.~a"
                     major minor))
         (cl:cond


### PR DESCRIPTION
According to assimp changelog they've kept it ABI compatible with 3.3.1

https://github.com/assimp/assimp/releases/tag/v4.0.0

API COMPATIBILITY:
- Changed ABI-compatibility to v3.3.1, please rebuild your precompiled libraries ( see issue 1182 )