### PR TITLE
Add support for assimp 6.0.5

### DIFF
--- a/low-level.lisp
+++ b/low-level.lisp
@@ -74,7 +74,7 @@
                                      ;; including patch level starting at 5.3
                                      :5.3.0 :5.3.1
                                      :5.4.0 :5.4.1 :5.4.2 :5.4.3
-                                     :6.0.0 :6.0.1 :6.0.2 :6.0.3 :6.0.4)
+                                     :6.0.0 :6.0.1 :6.0.2 :6.0.3 :6.0.4 :6.0.5)
                           when (cl:eql i a)
                             do (cl:setf keep cl:t)
                           when keep
@@ -119,9 +119,9 @@
                                (cl:and (cl:= minor 4)
                                        (cl:<= 0 patch 3))))
                      (6 (cl:or (cl:and (cl:= minor 0)
-                                       (cl:<= 0 patch 4))))
+                                       (cl:<= 0 patch 5))))
                      (cl:t ()))
-          (cl:error "trying to link against unsupported version of assimp. 3.0-6.0.4 supported, got version ~a.~a~@[.~a~]"
+          (cl:error "trying to link against unsupported version of assimp. 3.0-6.0.5 supported, got version ~a.~a~@[.~a~]"
                     major minor patch))
         (cl:setf %version% new-version)
         (cl:setf %cflags% (cl:when (cl:or (cl:> major 5)
@@ -153,9 +153,9 @@
                                (cl:and (cl:= minor 4)
                                        (cl:<= 0 patch 3))))
                      (6 (cl:or (cl:and (cl:= minor 0)
-                                       (cl:<= 0 patch 4))))
+                                       (cl:<= 0 patch 5))))
                      (cl:t ()))
-          (cl:error "trying to link against unsupported version of assimp. 3.0-6.0.4 supported, got version ~a.~a"
+          (cl:error "trying to link against unsupported version of assimp. 3.0-6.0.5 supported, got version ~a.~a"
                     major minor))
         (cl:let ((cflags (cl:when (%v= :5.1+)
                            (ai-get-compile-flags))))

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -381,16 +381,16 @@
 (defun translate-ai-color3f (c)
   (when (not (cffi:null-pointer-p c))
     (%ai::vcase
-      ((5 4 3) (translate-vector c 3 :float 'single-float))
+      ((5 4 3) (translate-vector c 3 :float single-float))
       ((4 0 0) (translate-vector c 3 %ai:ai-real %ai:real))
-      ((3 0 0) (translate-vector c 3 :float 'single-float)))))
+      ((3 0 0) (translate-vector c 3 :float single-float)))))
 
 (defun translate-ai-color4f (c)
   (when (not (cffi:null-pointer-p c))
     (%ai::vcase
-      ((5 4 3) (translate-vector c 4 :float 'single-float))
+      ((5 4 3) (translate-vector c 4 :float single-float))
       ((4 0 0) (translate-vector c 4 %ai:ai-real %ai:real))
-      ((3 0 0) (translate-vector c 4 :float 'single-float)))))
+      ((3 0 0) (translate-vector c 4 :float single-float)))))
 
 (defun translate-uint (p)
   (cffi:mem-aref p :unsigned-int))

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -1153,7 +1153,8 @@
 (defun import-into-lisp (filename &key processing-flags raw-times properties)
   ;; see config.lisp for PROPERTIES values/usage
   (check-version)
-  (let ((raw-scene nil) (*loader-translate-times* (not raw-times)))
+  (let ((raw-scene nil) (*loader-translate-times* (not raw-times))
+        (filename (uiop:native-namestring (truename filename))))
     (prog1
         (unwind-protect
              (let ((flags (cffi:foreign-bitfield-value
@@ -1165,9 +1166,9 @@
                        (if properties
                            (with-property-store (store :properties properties)
                              (%ai:ai-import-file-ex-with-properties
-                              (namestring filename) flags
+                              filename flags
                               (cffi:null-pointer) store))
-                           (%ai:ai-import-file (namestring filename) flags))))
+                           (%ai:ai-import-file filename flags))))
                (when (and (cffi:null-pointer-p raw-scene)
                           *translate-verbose*)
                  (format t "  import failed: ~s~%" (%ai:ai-get-error-string)))

--- a/wrappers.lisp
+++ b/wrappers.lisp
@@ -809,7 +809,8 @@
                  ;; https://github.com/assimp/assimp/issues/2997
                  (when (and (member *wrapper-version*
                                     '(:|5.0| :|5.1| :|5.2| :|5.3| :|5.3.1|
-                                      :|6.0.0| :|6.0.1| :|6.0.2| :|6.0.3| :|6.0.4|))
+                                      :|6.0.0| :|6.0.1| :|6.0.2| :|6.0.3| :|6.0.4|
+                                      :|6.0.5|))
                             (= %ai:m-data-length 1)
                             (eql type :uint)
                             (eql %ai:m-type :ai-pti-buffer))


### PR DESCRIPTION
Also fix style-warnings on SBCL (fix the type) + resolve truename of the input file in `import-into-lisp`